### PR TITLE
t.sentinel.mask: r.reclass.area workaround

### DIFF
--- a/t.sentinel.mask/t.sentinel.mask.py
+++ b/t.sentinel.mask/t.sentinel.mask.py
@@ -276,29 +276,43 @@ def main():
     for s2_scene_name in s2_scenes:
         s2_scene = s2_scenes[s2_scene_name]
         newmapset = s2_scene['clouds']
-        if grass.find_file(s2_scene['clouds'], element = 'raster',mapset = newmapset)['file']:
+        if grass.find_file(s2_scene['clouds'], element='raster',mapset=newmapset)['file']:
             if options['min_size_clouds']:
-                grass.run_command(
-                    'r.reclass.area',
-                    input="%s@%s" % (s2_scene['clouds'], newmapset),
-                    output=s2_scene['clouds'],
-                    value=options['min_size_clouds'],
-                    mode='greater',
-                    quiet=True)
+                try:
+                    grass.run_command(
+                        'r.reclass.area',
+                        input="%s@%s" % (s2_scene['clouds'], newmapset),
+                        output=s2_scene['clouds'],
+                        value=options['min_size_clouds'],
+                        mode='greater',
+                        quiet=True)
+                except Exception as e:
+                    # todo: remove workaround once r.reclass.area is updated
+                    grass.message(_('No clouds larger than %s detected. Image is considered cloudfree.'))
+                    exp_null = '%s = null()' % s2_scene['clouds']
+                    grass.run_command('r.mapcalc', expression=exp_null,
+                                      quiet=True)
             else:
                 grass.run_command('g.copy', raster="%s@%s,%s" % (s2_scene['clouds'], newmapset, s2_scene['clouds']))
         else:
             grass.run_command('r.mapcalc', expression="%s = null()" % s2_scene['clouds'])
         if options['output_shadows']:
-            if grass.find_file(s2_scene['shadows'], element = 'raster',mapset = newmapset)['file']:
+            if grass.find_file(s2_scene['shadows'], element='raster',mapset=newmapset)['file']:
                 if options['min_size_shadows']:
-                    grass.run_command(
-                        'r.reclass.area',
-                        input="%s@%s" % (s2_scene['shadows'], newmapset),
-                        output=s2_scene['shadows'],
-                        value=options['min_size_shadows'],
-                        mode='greater',
-                        quiet=True)
+                    try:
+                        grass.run_command(
+                            'r.reclass.area',
+                            input="%s@%s" % (s2_scene['shadows'], newmapset),
+                            output=s2_scene['shadows'],
+                            value=options['min_size_shadows'],
+                            mode='greater',
+                            quiet=True)
+                    except Exception as e:
+                        # todo: remove workaround once r.reclass.area is updated
+                        grass.message(_('No shadows larger than %s detected. Image is considered shadowfree.'))
+                        exp_null = '%s = null()' % s2_scene['shadows']
+                        grass.run_command('r.mapcalc', expression=exp_null,
+                                          quiet=True)
                 else:
                     grass.run_command('g.copy', raster="%s@%s,%s" % (s2_scene['shadows'], newmapset, s2_scene['shadows']))
             else:

--- a/t.sentinel.mask/t.sentinel.mask.py
+++ b/t.sentinel.mask/t.sentinel.mask.py
@@ -288,7 +288,7 @@ def main():
                         quiet=True)
                 except Exception as e:
                     # todo: remove workaround once r.reclass.area is updated
-                    grass.message(_('No clouds larger than %s detected. Image is considered cloudfree.'))
+                    grass.message(_('No clouds larger than %s ha detected. Image is considered cloudfree.' % options['min_size_clouds']))
                     exp_null = '%s = null()' % s2_scene['clouds']
                     grass.run_command('r.mapcalc', expression=exp_null,
                                       quiet=True)
@@ -309,7 +309,7 @@ def main():
                             quiet=True)
                     except Exception as e:
                         # todo: remove workaround once r.reclass.area is updated
-                        grass.message(_('No shadows larger than %s detected. Image is considered shadowfree.'))
+                        grass.message(_('No shadows larger than %s ha detected. Image is considered shadowfree.' % options['min_size_shadows']))
                         exp_null = '%s = null()' % s2_scene['shadows']
                         grass.run_command('r.mapcalc', expression=exp_null,
                                           quiet=True)


### PR DESCRIPTION
When applying a minimum cloud/shadow size to `t.sentinel.mask`, `r.reclass.area` fails if no areas are found that match this criterion. This PR provides a workaround. On a long term perspective, `r.reclass.area` may be updated to allow for the creation of an empty raster if the size criterion does not match.