### PR TITLE
t.sentinel.import: adapt for USGS download and sen2cor

### DIFF
--- a/t.sentinel.import/t.sentinel.import.html
+++ b/t.sentinel.import/t.sentinel.import.html
@@ -25,7 +25,7 @@ t.sentinel.import s2names=s2names2.txt settings=/mnt/pgpass/.sentinel.txt \
 If atmospheric correction should be run using the <b>-a</b> flag,
 <a href="http://step.esa.int/main/snap-supported-plugins/sen2cor/">Sen2Cor</a>
 needs to be installed. For additional information, see
-<a href="i.sentinel-2.sen2cor.html">i.sentinel-2.sen2cor.html</a>.
+<a href="i.sentinel-2.sen2cor.html">i.sentinel-2.sen2cor</a>.
 
 <h2>AUTHOR</h2>
 

--- a/t.sentinel.import/t.sentinel.import.html
+++ b/t.sentinel.import/t.sentinel.import.html
@@ -22,7 +22,7 @@ t.sentinel.import s2names=s2names2.txt settings=/mnt/pgpass/.sentinel.txt \
 </em>
 
 <h2>REQUIREMENTS</h2>
-If atmospherical correction should be run using the <b>-a</b> flag,
+If atmospheric correction should be run using the <b>-a</b> flag,
 <a href="http://step.esa.int/main/snap-supported-plugins/sen2cor/">Sen2Cor</a>
 needs to be installed. For additional information, see
 <a href="i.sentinel-2.sen2cor.html">i.sentinel-2.sen2cor.html</a>.

--- a/t.sentinel.import/t.sentinel.import.html
+++ b/t.sentinel.import/t.sentinel.import.html
@@ -15,10 +15,17 @@ t.sentinel.import s2names=s2names2.txt settings=/mnt/pgpass/.sentinel.txt \
 <a href="i.sentinel.download.html">i.sentinel.download</a>,
 <a href="i.sentinel.import.html">i.sentinel.import</a>,
 <a href="i.sentinel.parallel.download.html">i.sentinel.parallel.download</a>,
+<a href="i.sentinel-2.sen2cor.html">i.sentinel-2.sen2cor.html</a>,
 <a href="i.sentinel.import.worker.html">i.sentinel.import.worker</a>,
 <a href="t.create.html">t.create</a>,
 <a href="t.register.html">t.register</a>
 </em>
+
+<h2>REQUIREMENTS</h2>
+If atmospherical correction should be run using the <b>-a</b> flag,
+<a href="http://step.esa.int/main/snap-supported-plugins/sen2cor/">Sen2Cor</a>
+needs to be installed. For additional information, see
+<a href="i.sentinel-2.sen2cor.html">i.sentinel-2.sen2cor.html</a>.
 
 <h2>AUTHOR</h2>
 

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -121,7 +121,7 @@
 #% key: sen2cor_path
 #% required: no
 #% type: string
-#% label: path to sen2cor home directory
+#% label: Path to sen2cor home directory
 #% description: e.g. /home/user/sen2cor
 #%end
 

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -94,7 +94,7 @@
 
 #%option
 #% key: datasource
-#% description: Data-Hub to download scenes from.
+#% description: Data-Hub to download scenes from
 #% label: Default is ESA Copernicus Open Access Hub (ESA_COAH), but Sentinel-2 L1C data can also be acquired from USGS Earth Explorer (USGS_EE). Download from USGS is currently only available when used together with the scene_name option.
 #% options: ESA_COAH,USGS_EE
 #% answer: ESA_COAH

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -62,7 +62,7 @@
 #%option
 #% key: clouds
 #% type: integer
-#% description: Maximum cloud cover percentage for Sentinel scene
+#% description: Maximum cloud cover percentage for Sentinel-2 scene
 #% required: no
 #% guisection: Filter
 #% answer: 100

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -50,7 +50,7 @@
 
 #%flag
 #% key: a
-#% description: run atmospherical correction with sen2cor before importing
+#% description: run atmospheric correction with sen2cor before importing
 #%end
 
 #%option G_OPT_F_INPUT
@@ -65,7 +65,7 @@
 #% description: Maximum cloud cover percentage for Sentinel scene
 #% required: no
 #% guisection: Filter
-#% answer: 20
+#% answer: 100
 #%end
 
 #%option
@@ -119,7 +119,7 @@
 
 #%option
 #% key: sen2cor_path
-#% required: yes
+#% required: no
 #% type: string
 #% label: path to sen2cor home directory
 #% description: e.g. /home/user/sen2cor
@@ -339,7 +339,7 @@ def main():
     number_of_scenes = len(os.listdir(download_dir))
     nprocs_final = min(number_of_scenes, int(options['nprocs']))
 
-    # run atmospherical correction
+    # run atmospheric correction
     if flags['a']:
         sen2cor_folder = os.path.join(tmpdirectory, 'sen2cor_{}'.format(
             os.getpid()))
@@ -349,7 +349,7 @@ def main():
             grass.fatal(_(
                 "Unable to create temporary sen2cor folder {}").format(
                 sen2cor_folder))
-        grass.message(_('Starting atmospherical correction with sen2cor...').format(nprocs_final))
+        grass.message(_('Starting atmospheric correction with sen2cor...').format(nprocs_final))
         queue_sen2cor = ParallelModuleQueue(nprocs=nprocs_final)
         for idx, subfolder in enumerate(os.listdir(download_dir)):
             folderpath = os.path.join(download_dir, subfolder)

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -50,7 +50,7 @@
 
 #%flag
 #% key: a
-#% description: run atmospheric correction with sen2cor before importing
+#% description: Run atmospheric correction with sen2cor before importing
 #%end
 
 #%option G_OPT_F_INPUT

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -71,7 +71,7 @@
 #%option
 #% key: producttype
 #% type: string
-#% description: Sentinel product type to filter
+#% description: Sentinel-2 product type to filter
 #% required: no
 #% options: S2MSI1C,S2MSI2A,S2MSI2Ap
 #% answer: S2MSI2A


### PR DESCRIPTION
This PR adapts `t.sentinel.import` as follows:

- extends t.sentinel.import to more free download options, also without `s2names`, but with `start`/`end`/`producttype`/`cloud` filters instead
- also allows for download from USGS (by `datasource` option)
- optionally runs atmospherical correction using `sen2cor` and the Grass Addon `i.sentinel-2.sen2cor` (especially useful when downloading from USGS, where only L1C data are available) 
- [added 08.03.2021]: Cloud and Shadow rasters from the same date+time but from different scenes (e.g. different UTM tiles) are patched together to a single raster respectively. This requires also adaptions to `t.rast.mosaic`: https://github.com/mundialis/t.rast.mosaic/pull/3
