### PR TITLE
t.sentinel.mask: skip processing for null() rasters

### DIFF
--- a/t.sentinel.mask/t.sentinel.mask.py
+++ b/t.sentinel.mask/t.sentinel.mask.py
@@ -177,6 +177,13 @@ def main():
     times = [x.split('|')[2] for x in grass.parse_command('t.rast.list', input=strds, flags='u')]
     s2_scenes = dict()
     for strdsrast, time in zip(strdsrasters, times):
+        # check if strdsrast has data, skip otherwise
+        stats = grass.parse_command("r.info", map=strdsrast, flags="r")
+        if stats["min"] == "NULL" and stats["max"] == "NULL":
+            grass.warning(_("Raster {} only consists of NULL() in current "
+                            "region. Cloud/shadow detection "
+                            "is skipped.").format(strdsrast))
+            continue
         parts = strdsrast.split('_')
         name = "%s_%s" % (parts[0],parts[1])
         band = parts[2]


### PR DESCRIPTION
When using `t.sentinel.import` before `t.sentinel.mask`; the usage of `i.zero2null` (from within `t.sentinel.import`) can lead to a complete `null()` raster in the current region. 

This PR adapts `t.sentinel.mask` such that cloud/shadow calculation is skipped for such scenes.