### PR TITLE
i.sentinel.import.worker: metadata and -j are mutually exclusive

### DIFF
--- a/i.sentinel.import.worker/i.sentinel.import.worker.py
+++ b/i.sentinel.import.worker/i.sentinel.import.worker.py
@@ -116,6 +116,10 @@
 #% description: reclassify pixels with value 0 to null() using i.zero2null
 #%end
 
+#%rules
+#% exclusive: metadata,-j
+#%end
+
 
 import atexit
 import os


### PR DESCRIPTION
This PR:
- adds the `g.parser` rule that `metadata` and `-j` are mutually exclusive, as they are in the called addon `i.sentinel.import`. Without this fix, using both `metadata` and `-j` is possible in `i.sentinel.import.worker` but the error is not caught since `i.sentinel.import` is called via `grass.Popen`. 
- checks if the grass version is at least g79 and if so, adds the Sentinel2-Band information to the raster (can be checked with `i.band operation=print map=...`)