### PR TITLE
t.sentinel.import: create output dir if it does not exist

### DIFF
--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -391,6 +391,10 @@ def main():
                         filepath = os.path.join(folderpath, file)
             output_dir = os.path.join(
                 sen2cor_folder, 'sen2cor_result_{}'.format(idx))
+            try:
+                os.makedirs(output_dir)
+            except Exception:
+                grass.fatal(_('Unable to create directory {}').format(output_dir))
             sen2cor_module = Module(
                 'i.sentinel-2.sen2cor',
                 input_file=filepath,


### PR DESCRIPTION
This PR creates a sen2cor output dir in `t.sentinel.import` if it does not exist (sen2cor may run into problems if the desired output dir does not exist)