### PR TITLE
WIP: t.sentinel.mask: Add postgresql option

### DIFF
--- a/t.sentinel.mask/t.sentinel.mask.py
+++ b/t.sentinel.mask/t.sentinel.mask.py
@@ -97,9 +97,27 @@
 #% answer: 1
 #%end
 
+#%option
+#% key: pg_database
+#% type: string
+#% required: no
+#% multiple: no
+#% description: Name of optional PostgreSQL database to use as vector attribute connection
+#%end
+
+#%option
+#% key: pg_user
+#% type: string
+#% required: no
+#% multiple: no
+#% description: Name of the PostgreSQL user
+#% answer: postgres
+#%end
+
 #%rules
 #% requires_all: output_shadows,metadata
 #% requires_all: threshold,metadata
+#% collective: pg_database,pg_user
 #%end
 
 import atexit
@@ -247,9 +265,12 @@ def main():
                 kwargs['shadow_raster'] = s2_scene['shadows']
                 kwargs['metadata'] = s2_scene['metadata']
                 kwargs['shadow_threshold'] = 1000
-                flags='s'
+                flags = 's'
             else:
-                flags='sc'
+                flags = 'sc'
+            if options["pg_database"]:
+                kwargs["pg_database"] = options["pg_database"]
+                kwargs["pg_user"] = options["pg_user"]
             newmapset = s2_scene['clouds']
             # grass.run_command(
             i_sentinel_mask = Module(


### PR DESCRIPTION
This PR adds two options to `t.sentinel.mask` and `i.sentinel.mask.worker` in order to set the vector database connection in the temporary mapsets to PostgreSQL. This may be preferred because it was observed that using t.sentinel.mask with the default SQlite database on an NFS filesystem leads to long calculation times of `v.select` (a step from `i.sentinel.mask.worker`). 

## please note
that postgresql needs to be properly installed and configured, and the database needs to be initialized and started for this option to work. See also: https://luppeng.wordpress.com/2020/02/28/install-and-start-postgresql-on-alpine-linux/