### PR TITLE
t.sentinel.import: fix import for local zip files

### DIFF
--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -452,9 +452,11 @@ def main():
                 if subfolder.endswith(".SAFE"):
                     pattern_file = subfolder.split(".SAFE")[0]
                 elif subfolder.endswith(".zip"):
-                    pattern_file = subfolder.split(".SAFE.zip")[0]
+                    pattern_file = subfolder.split(".zip")[0]
+                    if ".SAFE" in pattern_file:
+                        pattern_file = pattern_file.split(".SAFE")[0]
                 else:
-                    grass.warning(_("{} is not in .SAFE or SAFE.zip format, "
+                    grass.warning(_("{} is not in .SAFE or .zip format, "
                                     "skipping...").format(
                                     os.path.join(download_dir, subfolder)))
                     continue


### PR DESCRIPTION
If the local Sentinel-2 scenes are not in `.SAFE` but in `.SAFE.zip` format, `t.sentinel.import` does not import anything because of a wrong `os.path.isdir()` and `pattern_file` check. This is fixed in this PR. 