### PR TITLE
t.sentinel: add missing white space to parser section

### DIFF
--- a/i.sentinel.import.worker/i.sentinel.import.worker.py
+++ b/i.sentinel.import.worker/i.sentinel.import.worker.py
@@ -22,103 +22,103 @@
 #
 ############################################################################
 
-#%module
-#% description: Imports Sentinel-2 data into a new mapset, and optionally resamples bands to 10m.
-#% keyword: imagery
-#% keyword: satellite
-#% keyword: Sentinel
-#% keyword: import
-#%end
+# %module
+# % description: Imports Sentinel-2 data into a new mapset, and optionally resamples bands to 10m.
+# % keyword: imagery
+# % keyword: satellite
+# % keyword: Sentinel
+# % keyword: import
+# %end
 
-#%option G_OPT_F_INPUT
-#% key: input
-#% type: string
-#% required: yes
-#% multiple: no
-#% key_desc: name
-#% description: Name of input directory with downloaded Sentinel data
-#%end
+# %option G_OPT_F_INPUT
+# % key: input
+# % type: string
+# % required: yes
+# % multiple: no
+# % key_desc: name
+# % description: Name of input directory with downloaded Sentinel data
+# %end
 
-#%option
-#% key: pattern
-#% type: string
-#% required: no
-#% multiple: no
-#% description: Band name pattern to import
-#%end
+# %option
+# % key: pattern
+# % type: string
+# % required: no
+# % multiple: no
+# % description: Band name pattern to import
+# %end
 
-#%option
-#% key: pattern_file
-#% type: string
-#% required: no
-#% multiple: no
-#% description: File name pattern to import
-#%end
+# %option
+# % key: pattern_file
+# % type: string
+# % required: no
+# % multiple: no
+# % description: File name pattern to import
+# %end
 
-#%option
-#% key: mapsetid
-#% type: string
-#% required: yes
-#% multiple: no
-#% description: ID for mapset
-#%end
+# %option
+# % key: mapsetid
+# % type: string
+# % required: yes
+# % multiple: no
+# % description: ID for mapset
+# %end
 
-#%option
-#% key: region
-#% type: string
-#% required: no
-#% multiple: no
-#% key_desc: name
-#% description: Set current region from named region
-#%end
+# %option
+# % key: region
+# % type: string
+# % required: no
+# % multiple: no
+# % key_desc: name
+# % description: Set current region from named region
+# %end
 
-#%option G_OPT_MEMORYMB
-#%end
+# %option G_OPT_MEMORYMB
+# %end
 
-#%option
-#% key: directory
-#% type: string
-#% required: no
-#% multiple: no
-#% description: Directory to hold temporary files (they can be large)
-#%end
+# %option
+# % key: directory
+# % type: string
+# % required: no
+# % multiple: no
+# % description: Directory to hold temporary files (they can be large)
+# %end
 
-#%option G_OPT_M_DIR
-#% key: metadata
-#% description: Name of directory into which Sentinel metadata json dumps are saved
-#% required: no
-#%end
+# %option G_OPT_M_DIR
+# % key: metadata
+# % description: Name of directory into which Sentinel metadata json dumps are saved
+# % required: no
+# %end
 
-#%flag
-#% key: r
-#% description: Reproject raster data using r.import if needed
-#%end
+# %flag
+# % key: r
+# % description: Reproject raster data using r.import if needed
+# %end
 
-#%flag
-#% key: i
-#% description: Resample 20/60m bands to 10m using r.resamp.interp
-#%end
+# %flag
+# % key: i
+# % description: Resample 20/60m bands to 10m using r.resamp.interp
+# %end
 
-#%flag
-#% key: c
-#% description: Import cloud masks as raster maps
-#% guisection: Settings
-#%end
+# %flag
+# % key: c
+# % description: Import cloud masks as raster maps
+# % guisection: Settings
+# %end
 
-#%flag
-#% key: j
-#% description: Write metadata json for each band to LOCATION/MAPSET/json folder
-#% guisection: Print
-#%end
+# %flag
+# % key: j
+# % description: Write metadata json for each band to LOCATION/MAPSET/json folder
+# % guisection: Print
+# %end
 
-#%flag
-#% key: n
-#% description: reclassify pixels with value 0 to null() using i.zero2null
-#%end
+# %flag
+# % key: n
+# % description: reclassify pixels with value 0 to null() using i.zero2null
+# %end
 
-#%rules
-#% exclusive: metadata,-j
-#%end
+# %rules
+# % exclusive: metadata,-j
+# %end
 
 
 import atexit

--- a/i.sentinel.mask.worker/i.sentinel.mask.worker.py
+++ b/i.sentinel.mask.worker/i.sentinel.mask.worker.py
@@ -22,160 +22,160 @@
 #
 ############################################################################
 
-#%module
-#% description: Runs i.sentinel.mask as a worker in different mapsets usually called by t.sentinel.mask.
-#% keyword: imagery
-#% keyword: satellite
-#% keyword: Sentinel
-#% keyword: cloud detection
-#% keyword: shadow
-#% keyword: reflectance
-#%end
-#%option
-#% key: newmapset
-#% type: string
-#% required: yes
-#% multiple: no
-#% key_desc: name
-#% description: Name of new mapset to run i.sentinel.mask
-#% guisection: Required
-#%end
-#%option G_OPT_F_INPUT
-#% key: input_file
-#% description: Name of the .txt file containing the list of input bands
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_R_INPUT
-#% key: blue
-#% description: Blue input band
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_R_INPUT
-#% key: green
-#% description: Green input band
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_R_INPUT
-#% key: red
-#% description: Red input band
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_R_INPUT
-#% key: nir
-#% description: NIR input band
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_R_INPUT
-#% key: nir8a
-#% description: NIR8a input band
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_R_INPUT
-#% key: swir11
-#% description: SWIR11 input band
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_R_INPUT
-#% key: swir12
-#% description: SWIR12 input band
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_V_OUTPUT
-#% key: cloud_mask
-#% description: Name of output vector cloud mask
-#% required : no
-#% guisection: Output
-#%end
-#%option G_OPT_R_OUTPUT
-#% key: cloud_raster
-#% description: Name of output raster cloud mask
-#% required : no
-#% guisection: Output
-#%end
-#%option G_OPT_V_OUTPUT
-#% key: shadow_mask
-#% description: Name of output vector shadow mask
-#% required : no
-#% guisection: Output
-#%end
-#%option G_OPT_R_OUTPUT
-#% key: shadow_raster
-#% description: Name of output vector shadow mask
-#% required : no
-#% guisection: Output
-#%end
-#%option
-#% key: cloud_threshold
-#% type: integer
-#% description: Threshold for cleaning small areas from cloud mask (in square meters)
-#% required : yes
-#% answer: 50000
-#% guisection: Parameters
-#%end
-#%option
-#% key: shadow_threshold
-#% type: integer
-#% description: Threshold for cleaning small areas from shadow mask (in square meters)
-#% required : yes
-#% answer: 10000
-#% guisection: Parameters
-#%end
-#%option G_OPT_F_INPUT
-#% key: mtd_file
-#% description: Name of the image metadata file (MTD_TL.xml)
-#% required : no
-#% guisection: Metadata
-#%end
-#%option G_OPT_F_INPUT
-#% key: metadata
-#% description: Name of Sentinel metadata json dump
-#% required : no
-#% guisection: Metadata
-#%end
-#%option
-#% key: scale_fac
-#% type: integer
-#% description: Rescale factor
-#% required : no
-#% answer: 10000
-#% guisection: Parameters
-#%end
-#%flag
-#% key: r
-#% description: Set computational region to maximum image extent
-#%end
-#%flag
-#% key: t
-#% description: Do not delete temporary files
-#%end
-#%flag
-#% key: s
-#% description: Rescale input bands
-#% guisection: Parameters
-#%end
-#%flag
-#% key: c
-#% description: Compute only the cloud mask
-#%end
+# %module
+# % description: Runs i.sentinel.mask as a worker in different mapsets usually called by t.sentinel.mask.
+# % keyword: imagery
+# % keyword: satellite
+# % keyword: Sentinel
+# % keyword: cloud detection
+# % keyword: shadow
+# % keyword: reflectance
+# %end
+# %option
+# % key: newmapset
+# % type: string
+# % required: yes
+# % multiple: no
+# % key_desc: name
+# % description: Name of new mapset to run i.sentinel.mask
+# % guisection: Required
+# %end
+# %option G_OPT_F_INPUT
+# % key: input_file
+# % description: Name of the .txt file containing the list of input bands
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_R_INPUT
+# % key: blue
+# % description: Blue input band
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_R_INPUT
+# % key: green
+# % description: Green input band
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_R_INPUT
+# % key: red
+# % description: Red input band
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_R_INPUT
+# % key: nir
+# % description: NIR input band
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_R_INPUT
+# % key: nir8a
+# % description: NIR8a input band
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_R_INPUT
+# % key: swir11
+# % description: SWIR11 input band
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_R_INPUT
+# % key: swir12
+# % description: SWIR12 input band
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_V_OUTPUT
+# % key: cloud_mask
+# % description: Name of output vector cloud mask
+# % required : no
+# % guisection: Output
+# %end
+# %option G_OPT_R_OUTPUT
+# % key: cloud_raster
+# % description: Name of output raster cloud mask
+# % required : no
+# % guisection: Output
+# %end
+# %option G_OPT_V_OUTPUT
+# % key: shadow_mask
+# % description: Name of output vector shadow mask
+# % required : no
+# % guisection: Output
+# %end
+# %option G_OPT_R_OUTPUT
+# % key: shadow_raster
+# % description: Name of output vector shadow mask
+# % required : no
+# % guisection: Output
+# %end
+# %option
+# % key: cloud_threshold
+# % type: integer
+# % description: Threshold for cleaning small areas from cloud mask (in square meters)
+# % required : yes
+# % answer: 50000
+# % guisection: Parameters
+# %end
+# %option
+# % key: shadow_threshold
+# % type: integer
+# % description: Threshold for cleaning small areas from shadow mask (in square meters)
+# % required : yes
+# % answer: 10000
+# % guisection: Parameters
+# %end
+# %option G_OPT_F_INPUT
+# % key: mtd_file
+# % description: Name of the image metadata file (MTD_TL.xml)
+# % required : no
+# % guisection: Metadata
+# %end
+# %option G_OPT_F_INPUT
+# % key: metadata
+# % description: Name of Sentinel metadata json dump
+# % required : no
+# % guisection: Metadata
+# %end
+# %option
+# % key: scale_fac
+# % type: integer
+# % description: Rescale factor
+# % required : no
+# % answer: 10000
+# % guisection: Parameters
+# %end
+# %flag
+# % key: r
+# % description: Set computational region to maximum image extent
+# %end
+# %flag
+# % key: t
+# % description: Do not delete temporary files
+# %end
+# %flag
+# % key: s
+# % description: Rescale input bands
+# % guisection: Parameters
+# %end
+# %flag
+# % key: c
+# % description: Compute only the cloud mask
+# %end
 
-#%rules
-#% collective: blue,green,red,nir,nir8a,swir11,swir12
-#% requires: shadow_mask,mtd_file,metadata
-#% requires: shadow_raster,mtd_file,metadata
-#% excludes: mtd_file,metadata
-#% required: cloud_mask,cloud_raster,shadow_mask,shadow_raster
-#% excludes: -c,shadow_mask,shadow_raster
-#% required: input_file,blue,green,red,nir,nir8a,swir11,swir12,mtd_file
-#% excludes: input_file,blue,green,red,nir,nir8a,swir11,swir12,mtd_file
-#%end
+# %rules
+# % collective: blue,green,red,nir,nir8a,swir11,swir12
+# % requires: shadow_mask,mtd_file,metadata
+# % requires: shadow_raster,mtd_file,metadata
+# % excludes: mtd_file,metadata
+# % required: cloud_mask,cloud_raster,shadow_mask,shadow_raster
+# % excludes: -c,shadow_mask,shadow_raster
+# % required: input_file,blue,green,red,nir,nir8a,swir11,swir12,mtd_file
+# % excludes: input_file,blue,green,red,nir,nir8a,swir11,swir12,mtd_file
+# %end
 
 import sys
 import os

--- a/t.sentinel.mask/t.sentinel.mask.py
+++ b/t.sentinel.mask/t.sentinel.mask.py
@@ -17,90 +17,90 @@
 #
 #############################################################################
 
-#%Module
-#% description: Creates a space time raster data set of cloud masks and shadow masks by running i.sentinel.mask parallelized.
-#% keyword: temporal
-#% keyword: satellite
-#% keyword: Sentinel
-#% keyword: cloud detection
-#% keyword: shadow detection
-#%end
+# %Module
+# % description: Creates a space time raster data set of cloud masks and shadow masks by running i.sentinel.mask parallelized.
+# % keyword: temporal
+# % keyword: satellite
+# % keyword: Sentinel
+# % keyword: cloud detection
+# % keyword: shadow detection
+# %end
 
-#%option
-#% key: input
-#% type: string
-#% required: yes
-#% multiple: no
-#% description: STRDS with Sentinel-2 scenes (with bands B02,B03,B04,B08,B8A,B11,B12)
-#%end
+# %option
+# % key: input
+# % type: string
+# % required: yes
+# % multiple: no
+# % description: STRDS with Sentinel-2 scenes (with bands B02,B03,B04,B08,B8A,B11,B12)
+# %end
 
-#%option
-#% key: threshold
-#% type: double
-#% required: no
-#% multiple: no
-#% description: Minimum ESA cloud percentage to trigger cloud and shadow detection.
-#% answer: 0
-#%end
+# %option
+# % key: threshold
+# % type: double
+# % required: no
+# % multiple: no
+# % description: Minimum ESA cloud percentage to trigger cloud and shadow detection.
+# % answer: 0
+# %end
 
-#%option
-#% key: output_clouds
-#% type: string
-#% required: yes
-#% multiple: no
-#% description: STRDS with cloud masks of Sentinel-2 scenes
-#%end
+# %option
+# % key: output_clouds
+# % type: string
+# % required: yes
+# % multiple: no
+# % description: STRDS with cloud masks of Sentinel-2 scenes
+# %end
 
-#%option
-#% key: min_size_clouds
-#% type: double
-#% required: no
-#% multiple: no
-#% description: Value option that sets the minimal area size limit (in hectares) of the clouds
-#%end
+# %option
+# % key: min_size_clouds
+# % type: double
+# % required: no
+# % multiple: no
+# % description: Value option that sets the minimal area size limit (in hectares) of the clouds
+# %end
 
-#%option
-#% key: output_shadows
-#% type: string
-#% required: no
-#% multiple: no
-#% description: STRDS with shodow masks of Sentinel-2 scenes
-#%end
+# %option
+# % key: output_shadows
+# % type: string
+# % required: no
+# % multiple: no
+# % description: STRDS with shodow masks of Sentinel-2 scenes
+# %end
 
-#%option
-#% key: min_size_shadows
-#% type: double
-#% required: no
-#% multiple: no
-#% description: Value option that sets the minimal area size limit (in hectares) of the cloud shadows
-#%end
+# %option
+# % key: min_size_shadows
+# % type: double
+# % required: no
+# % multiple: no
+# % description: Value option that sets the minimal area size limit (in hectares) of the cloud shadows
+# %end
 
-#%option
-#% key: metadata
-#% type: string
-#% required: no
-#% multiple: no
-#% key_desc: name
-#% label: Name of folder with Sentinel metadata json files
-#% description: Default is LOCATION/MAPSET/cell_misc/
-#% gisprompt: old,file,file
-#% answer: default
-#% guisection: Metadata
-#%end
+# %option
+# % key: metadata
+# % type: string
+# % required: no
+# % multiple: no
+# % key_desc: name
+# % label: Name of folder with Sentinel metadata json files
+# % description: Default is LOCATION/MAPSET/cell_misc/
+# % gisprompt: old,file,file
+# % answer: default
+# % guisection: Metadata
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% required: no
-#% multiple: no
-#% label: Number of parallel processes to use
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % required: no
+# % multiple: no
+# % label: Number of parallel processes to use
+# % answer: 1
+# %end
 
-#%rules
-#% requires_all: output_shadows,metadata
-#% requires_all: threshold,metadata
-#%end
+# %rules
+# % requires_all: output_shadows,metadata
+# % requires_all: threshold,metadata
+# %end
 
 import atexit
 from datetime import datetime


### PR DESCRIPTION
Adds white space to avoid Python code formatting errors.

Done with:

`ag "#%" -l | xargs sed -i 's|^#%|# %|g'`