### PR TITLE
t.sentinel.import: Fix missing 20m/60m STRDS

### DIFF
--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -568,7 +568,7 @@ def main():
 
         for band in bands:
             if flags['i'] and ('20' in band or '60' in band):
-                band.replace('20', '10').replace('60', '10')
+                band = band.replace('20', '10').replace('60', '10')
             grass.run_command('t.rast.extract', input=strds, where="name like '%" + band + "%'", output="%s_%s" % (strds, band), quiet=True)
             grass.message("<%s_%s> is created" % (strds, band))
 


### PR DESCRIPTION
This Mini PR fixes the bug that no STRDS for 20m and 60m bands are created in case they are resampled to 10m using the `-i` flag