### PR TITLE
t.sentinel.import: specify cloud STDS import

### DIFF
--- a/i.sentinel.import.worker/i.sentinel.import.worker.py
+++ b/i.sentinel.import.worker/i.sentinel.import.worker.py
@@ -89,6 +89,16 @@
 # % required: no
 # %end
 
+# %option
+# % key: cloud_output
+# % type: string
+# % required: no
+# % multiple: no
+# % options: vector,raster
+# % answer: vector
+# % label: Create cloud mask as raster or vector map
+# %end
+
 # %flag
 # % key: r
 # % description: Reproject raster data using r.import if needed
@@ -248,6 +258,8 @@ def main():
         kwargs['metadata'] = options['metadata']
     if options["pattern_file"]:
         kwargs["pattern_file"] = options["pattern_file"]
+    if options["cloud_output"]:
+        kwargs["cloud_output"] = options["cloud_output"]
 
     kwargsstr = ""
     flagstr = ""

--- a/t.sentinel.import/t.sentinel.import.html
+++ b/t.sentinel.import/t.sentinel.import.html
@@ -2,6 +2,9 @@
 
 <em>t.sentinel.import</em> is a GRASS GIS addon Python script to
 download and import the Sentinel-2 scenes and create a STRDS.
+<p>
+Since Sentinel-2 <a href="https://forum.step.esa.int/t/info-introduction-of-additional-radiometric-offset-in-pb04-00-products/35431">Processing Baseline 4.0.0</a>, a systematic offset has been introduced to all reflectance values.
+To account for this, the <b>offset</b> option allows the user to indicate how reflectance data should be corrected (e.g. -1000).
 
 <h2>EXAMPLE</h2>
 

--- a/t.sentinel.import/t.sentinel.import.html
+++ b/t.sentinel.import/t.sentinel.import.html
@@ -4,10 +4,13 @@
 download and import the Sentinel-2 scenes and create a STRDS.
 <p>
 Since Sentinel-2 <a href="https://forum.step.esa.int/t/info-introduction-of-additional-radiometric-offset-in-pb04-00-products/35431">Processing Baseline 4.0.0</a>,
-a systematic offset has been introduced to all reflectance values.
+a systematic offset has been introduced to all reflectance values.<br>
 To account for this, the <b>offset</b> option allows the user to
 indicate how reflectance data should be corrected (e.g. -1000).
-
+<p>
+When using the <em>-c</em> flag to import cloud masks, the user may define the type and name of the <br>
+  cloud STDS to be imported by the <em>stvds_clouds</em>/<em>strds_clouds</em> option. If only the
+<em>-c</em> flag is given, a cloud STVDS is imported and named <em>[strds_output]_clouds</em>
 <h2>EXAMPLE</h2>
 
 <div class="code"><pre>

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -157,6 +157,15 @@
 # %end
 
 # %option
+# % key: strds_clouds
+# % type: string
+# % required: no
+# % multiple: no
+# % description: Name of the output cloudmask space time raster dataset. If not provided, it will be <strds_output>_clouds
+# % gisprompt: new,stds,stvds
+# %end
+
+# %option
 # % key: directory
 # % type: string
 # % required: no
@@ -210,6 +219,8 @@
 # % requires: -a, sen2cor_path
 # % requires: -e, s2names
 # % requires: stvds_clouds, -c
+# % requires: strds_clouds, -c
+# % exclusive: stvds_clouds, strds_clouds
 # %end
 
 
@@ -480,6 +491,11 @@ def main():
             }
             if options["extent"] == "region":
                 import_kwargs["region"] = currentregion
+            if flags["c"]:
+                if options["stvds_clouds"]:
+                    import_kwargs["cloud_output"] = "vector"
+                elif options["strds_clouds"]:
+                    import_kwargs["cloud_output"] = "raster"
             if single_folders is True:
                 directory = os.path.join(download_dir, subfolder)
             else:
@@ -519,36 +535,40 @@ def main():
             cloudlist.append(vect)
             grass.run_command('g.copy', vector=vect + '@' + new_mapset + ',' + vect)
         for rast in grass.parse_command('g.list', type='raster', mapset=new_mapset):
-            maplist.append(rast)
-            grass.run_command('g.copy', raster=rast + '@' + new_mapset + ',' + rast)
+            grass.run_command('g.copy',
+                              raster=rast + '@' + new_mapset + ',' + rast)
+            if "CLOUDS" in rast:
+                cloudlist.append(rast)
+            else:
+                maplist.append(rast)
 
-            if options["offset"]:
-                # save the description.json
-                tmp_desc_dir = os.path.join(tmpdirectory, "descriptions_json")
-                if not os.path.isdir(tmp_desc_dir):
-                    try:
-                        os.makedirs(tmp_desc_dir)
-                    except:
-                        grass.fatal(_(f"Unable to create directory {tmp_desc_dir}"))
+                if options["offset"]:
+                    # save the description.json
+                    tmp_desc_dir = os.path.join(tmpdirectory, "descriptions_json")
+                    if not os.path.isdir(tmp_desc_dir):
+                        try:
+                            os.makedirs(tmp_desc_dir)
+                        except:
+                            grass.fatal(_(f"Unable to create directory {tmp_desc_dir}"))
 
-                desc_file_save = os.path.join(tmp_desc_dir, f"{rast}_description.json")
-                desc_file_in = os.path.join(json_standard_folder, rast, "description.json")
-                shutil.copy(desc_file_in, desc_file_save)
+                    desc_file_save = os.path.join(tmp_desc_dir, f"{rast}_description.json")
+                    desc_file_in = os.path.join(json_standard_folder, rast, "description.json")
+                    shutil.copy(desc_file_in, desc_file_save)
 
-                # calculate offset (metadata in cell_misc will be lost)
-                tmp_rast = f"rast_tmp_{os.getpid()}"
-                mapc_exp = (f"{tmp_rast} = if({rast} + {options['offset']} < 0, "
-                            f"0, {rast} + {options['offset']} )")
-                grass.run_command(f"r.mapcalc.tiled",
-                                  expression=mapc_exp,
-                                  nprocs=nprocs_final,
-                                  quiet=True)
-                grass.run_command("g.copy",
-                                  raster=f"{tmp_rast},{rast}",
-                                  overwrite=True,
-                                  quiet=True)
-                # copy the description.json back
-                shutil.copy(desc_file_save, desc_file_in)
+                    # calculate offset (metadata in cell_misc will be lost)
+                    tmp_rast = f"rast_tmp_{os.getpid()}"
+                    mapc_exp = (f"{tmp_rast} = if({rast} + {options['offset']} < 0, "
+                                f"0, {rast} + {options['offset']} )")
+                    grass.run_command(f"r.mapcalc.tiled",
+                                      expression=mapc_exp,
+                                      nprocs=nprocs_final,
+                                      quiet=True)
+                    grass.run_command("g.copy",
+                                      raster=f"{tmp_rast},{rast}",
+                                      overwrite=True,
+                                      quiet=True)
+                    # copy the description.json back
+                    shutil.copy(desc_file_save, desc_file_in)
 
         grass.utils.try_rmdir(os.path.join(gisdbase, location, new_mapset))
     # space time dataset
@@ -587,13 +607,19 @@ def main():
         grass.try_remove(registerfile)
 
         if flags["c"]:
-            if options["stvds_clouds"]:
-                stvdsclouds = options["stvds_clouds"]
+            dtype="vector"
+            stds_type = "stvds"
+            if options["strds_clouds"]:
+                stdsclouds = options["strds_clouds"]
+                dtype="raster"
+                stds_type = "strds"
+            elif options["stvds_clouds"]:
+                stdsclouds = options["stvds_clouds"]
             else:
-                stvdsclouds = strds + '_clouds'
+                stdsclouds = strds + '_clouds'
             grass.run_command(
-                't.create', output=stvdsclouds, title="Sentinel-2_sen2cor_clouds",
-                desc="Sentinel-2_sen2cor_clouds", quiet=True, type='stvds')
+                't.create', output=stdsclouds, title="Sentinel-2_sen2cor_clouds",
+                desc="Sentinel-2_sen2cor_clouds", quiet=True, type=stds_type)
             registerfileclouds = grass.tempfile()
             fileclouds = open(registerfileclouds, 'w')
             for imp_clouds in cloudlist:
@@ -604,8 +630,8 @@ def main():
                 fileclouds.write("%s|%s %s\n" % (imp_clouds, date_str2, clock_str2))
             fileclouds.close()
             grass.run_command(
-                't.register', type='vector', input=stvdsclouds, file=registerfileclouds, quiet=True)
-            grass.message("<%s> is created" % (stvdsclouds))
+                't.register', type=dtype, input=stdsclouds, file=registerfileclouds, quiet=True)
+            grass.message("<%s> is created" % (stdsclouds))
             # remove registerfile
             grass.try_remove(registerfileclouds)
 

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -152,7 +152,7 @@
 # % type: string
 # % required: no
 # % multiple: no
-# % description: Name of the output cloudmask space time vector dataset
+# % description: Name of the output cloudmask space time vector dataset. If not provided, it will be <strds_output>_clouds
 # % gisprompt: new,stds,stvds
 # %end
 
@@ -586,8 +586,11 @@ def main():
         # remove registerfile
         grass.try_remove(registerfile)
 
-        if options["stvds_clouds"]:
-            stvdsclouds = options["stvds_clouds"]
+        if flags["c"]:
+            if options["stvds_clouds"]:
+                stvdsclouds = options["stvds_clouds"]
+            else:
+                stvdsclouds = strds + '_clouds'
             grass.run_command(
                 't.create', output=stvdsclouds, title="Sentinel-2_sen2cor_clouds",
                 desc="Sentinel-2_sen2cor_clouds", quiet=True, type='stvds')

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -153,7 +153,6 @@
 # % required: no
 # % multiple: no
 # % description: Name of the output cloudmask space time vector dataset. If not provided, it will be <strds_output>_clouds
-# % gisprompt: new,stds,stvds
 # %end
 
 # %option
@@ -162,7 +161,6 @@
 # % required: no
 # % multiple: no
 # % description: Name of the output cloudmask space time raster dataset. If not provided, it will be <strds_output>_clouds
-# % gisprompt: new,stds,stvds
 # %end
 
 # %option

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -148,6 +148,15 @@
 # %end
 
 # %option
+# % key: stvds_clouds
+# % type: string
+# % required: no
+# % multiple: no
+# % description: Name of the output cloudmask space time vector dataset
+# % gisprompt: new,stds,stvds
+# %end
+
+# %option
 # % key: directory
 # % type: string
 # % required: no
@@ -200,6 +209,7 @@
 # % required: input_dir, start, s2names
 # % requires: -a, sen2cor_path
 # % requires: -e, s2names
+# % requires: stvds_clouds, -c
 # %end
 
 
@@ -576,11 +586,11 @@ def main():
         # remove registerfile
         grass.try_remove(registerfile)
 
-        if flags['c']:
-            stvdsclouds = strds + '_clouds'
+        if options["stvds_clouds"]:
+            stvdsclouds = options["stvds_clouds"]
             grass.run_command(
-                't.create', output=stvdsclouds, title="Sentinel-2 clouds",
-                desc="Sentinel-2 clouds", quiet=True, type='stvds')
+                't.create', output=stvdsclouds, title="Sentinel-2_sen2cor_clouds",
+                desc="Sentinel-2_sen2cor_clouds", quiet=True, type='stvds')
             registerfileclouds = grass.tempfile()
             fileclouds = open(registerfileclouds, 'w')
             for imp_clouds in cloudlist:

--- a/t.sentinel.import/t.sentinel.import.py
+++ b/t.sentinel.import/t.sentinel.import.py
@@ -206,7 +206,7 @@
 # % key: offset
 # % type: integer
 # % required: no
-# % description: Offset to add to the Sentinel bands to due to specific processing baseline (e.g. -1000)
+# % description: Offset to add to the Sentinel-2 bands to due to specific processing baseline (e.g. -1000)
 # %end
 
 # %rules
@@ -490,9 +490,8 @@ def main():
             if options["extent"] == "region":
                 import_kwargs["region"] = currentregion
             if flags["c"]:
-                if options["stvds_clouds"]:
-                    import_kwargs["cloud_output"] = "vector"
-                elif options["strds_clouds"]:
+                import_kwargs["cloud_output"] = "vector"
+                if options["strds_clouds"]:
                     import_kwargs["cloud_output"] = "raster"
             if single_folders is True:
                 directory = os.path.join(download_dir, subfolder)
@@ -555,6 +554,7 @@ def main():
 
                     # calculate offset (metadata in cell_misc will be lost)
                     tmp_rast = f"rast_tmp_{os.getpid()}"
+                    # clipping to 0 to keep the value within the valid 0-10000 range
                     mapc_exp = (f"{tmp_rast} = if({rast} + {options['offset']} < 0, "
                                 f"0, {rast} + {options['offset']} )")
                     grass.run_command(f"r.mapcalc.tiled",


### PR DESCRIPTION
!! Note that changes from https://github.com/mundialis/t.sentinel/pull/23 are also present in this PR (but should be reviewed and merged first) !! 

This PR adapts `t.sentinel.import`, such that

- the optional output cloud STVDS can be named by the user rather than named automatically. The old option (STVDS creation is triggered by `-c` flag and the name is given automatically) is kept for backwards compatibility
- alternatively, the user can define a STRDS clouds output, in which case the cloud masks are imported as rasters and registered in a user defined STRDS
- a bug during STVDS creation is fixed, where spaces in the STVDS title/description caused an error: `Module run t.create --q output=s2_strds_timestep0_clouds ------> title=Sentinel-2 clouds desc=Sentinel-2 clouds <----- type=stvds ended with an error.`